### PR TITLE
Correct Table.ToMCode bug with text containing quotes

### DIFF
--- a/Library/Table.ToMCode.pq
+++ b/Library/Table.ToMCode.pq
@@ -2,14 +2,7 @@ let func =
  (Table as table) =>
 let
   Table = Table,
-  ReplaceNulls = Table.ReplaceValue(
-      Table, 
-      null, 
-      "", 
-      Replacer.ReplaceValue, 
-      Table.ColumnNames(Table)
-    ),
-  ListOfColumns = Table.ToRows(ReplaceNulls),
+  ListOfColumns = Table.ToRows(Table),
   ConvertToTable = Table.FromList(
       ListOfColumns, 
       Splitter.SplitByNothing(), 
@@ -20,23 +13,22 @@ let
   CoreString = Table.AddColumn(
       ConvertToTable, 
       "Custom", 
-      each Text.Combine(List.Transform([Column1], each Text.From(_)), """ ,""")
+      each Text.Combine(List.Transform([Column1], each if _ = null then "null" else """" & Text.Replace(Text.From(_),"""","""""") & """"), ", ")
     ),
   FullString = "= #table( {"""
     & Text.Combine(Table.ColumnNames(Table), """, """)
-    & """}, #(lf) { {"""
-    & Text.Combine(CoreString[Custom], """}, #(lf) {""")
-    & """} } ) ",
-  ReplaceBlanks = Text.Replace(FullString, """""", "null")
+    & """}, #(lf) { {"
+    & Text.Combine(CoreString[Custom], "}, #(lf) {")
+    & "} } ) "
 in
-  ReplaceBlanks,
+  FullString,
 documentation = [
 Documentation.Name =  " Table.ToMCode ",
 Documentation.Description = " Transforms a  <code>Table</code>  to a string of M code that will create that table in the query editor. ",
 Documentation.LongDescription = " Transforms a  <code>Table</code>  to a string of M code that will create that table in the query editor. ",
 Documentation.Category = " Table ",
 Documentation.Source = "  ",
-Documentation.Version = " 1.0 ",
+Documentation.Version = " 1.0.1 ",
 Documentation.Author = " Imke Feldmann: www.TheBIccountant.com . ",
 Documentation.Examples = {[Description =  "  ",
 Code = "  ",


### PR DESCRIPTION
Makes the following updates:

- FullString no longer creates the opening quotation mark for the first item in the row or the last item in the row, moving that task to CoreString
- CoreString's Text.From(_) call is now wrapped in a Text.Replace to catch quotation marks within the string, in turn wrapped in opening and closing quotes for the string
- null values are handled as a special case in CoreString, removing the need for ReplaceNulls & ReplaceBlanks -- ReplaceBlanks would undo the escaped quotation marks

Example Table to test as input:
```
= #table( {"Column1", "Column2", "Column3"}, 
 { {"1", null, "3"}, 
 {"4", "He said, ""Hi, there!"" and smiled.", "6"} } ) 
```